### PR TITLE
fix: broken assetnote link

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
             Unpack the source code of React and other Webpacked Javascript apps!
             Check out
             <a
-              href="https://blog.assetnote.io/bug-bounty/2020/02/01/expanding-attack-surface-react-native/"
+              href="https://www.assetnote.io/resources/research/expanding-the-attack-surface-react-native-android-applications"
               >Expanding the Attack Surface: React Native Android
               Applications</a
             >


### PR DESCRIPTION
## Problem

The link used to reference the assetnote article is no longer valid, the URL has been changed. I've updated the current article link.

Best regards,
oppsec.