### PR TITLE
fix: source map import with fixed version

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       type="text/css"
       href="https://unpkg.com/dialog-polyfill@latest/dist/dialog-polyfill.css"
     />
-    <script src="https://unpkg.com/source-map@latest/dist/source-map.js"></script>
+    <script src="https://unpkg.com/source-map@0.7.3/dist/source-map.js"></script>
     <script>
       sourceMap.SourceMapConsumer.initialize({
         "lib/mappings.wasm":


### PR DESCRIPTION
## Problem

This PR solves the error `ReferenceError: sourceMap is not defined` that is happening at the moment.

<img width="1119" height="209" alt="image" src="https://github.com/user-attachments/assets/34df6bfd-3992-4814-87cb-0ba4f65a9d00" />

The problem here happens because the link with the latest tag is broken: 

<img width="898" height="179" alt="image" src="https://github.com/user-attachments/assets/e7108245-2a23-4074-8b8e-89643cf51f2c" />

## Solution

- Fixed the source-map dependency version to `0.7.3`
